### PR TITLE
fixed bug that offset headings in mobile view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -92,6 +92,10 @@ body {
   width: 50%;
 }
 
+.justify-content-center {
+  justify-content: center;
+}
+
 [tabindex="-1"]:focus {
   outline: 0 !important;
 }

--- a/team.html
+++ b/team.html
@@ -87,11 +87,10 @@
 
     <div class="temnplateux-section">
       <div class="container">
-        <div class="row mb-5">
+        <div class="row mb-5 justify-content-center">
           <div class="col-md-12 block-heading-wrap" data-aos="fade-up">
-
+            
             <h2 class="heading mb-5 text-center">
-
               <i>Here to give hope</i>
             </h2>
             <h3 class="heading mb-5 text center"> Founding Team</h3>


### PR DESCRIPTION
- created justify-content-center class in style sheet
- added justify-content-center class to headings 

<img width="373" alt="Screen Shot 2021-07-28 at 3 52 28 PM" src="https://user-images.githubusercontent.com/61565065/127387028-18b23f93-c049-435d-8bf1-952ddfc4082d.png">
